### PR TITLE
Add support for block strings (triple quotes)

### DIFF
--- a/GraphQL.sublime-syntax
+++ b/GraphQL.sublime-syntax
@@ -13,10 +13,18 @@ contexts:
       scope: punctuation.definition.comment.graphql
       push: line_comment
 
+    - match: (""")
+      scope: punctuation.definition.comment.begin.graphql
+      push:
+        - meta_scope: comment.block.graphql
+        - match: (""")
+          scope: punctuation.definition.comment.end.graphql
+          pop: true
+
   main:
     # Strings begin and end with quotes, and use backslashes as an escape
     # character
-    - match: '"'
+    - match: '"\w+'
       scope: punctuation.definition.string.begin.graphql
       push: double_quoted_string
 


### PR DESCRIPTION
As per [GraphQL RFC](https://facebook.github.io/graphql/draft/#sec-String-Value) and its [implementation](https://github.com/facebook/graphql/pull/327), block strings are part of the spec for a while as a way to add multi-line documentation to GraphQL types. This PR adds syntax highlight support for triple quotes (""") block strings.