### PR TITLE
Support .graphqls as a file extension

### DIFF
--- a/GraphQL.sublime-syntax
+++ b/GraphQL.sublime-syntax
@@ -4,6 +4,7 @@
 name: GraphQL
 file_extensions:
   - graphql
+  - graphqls
   - gql
 scope: source.graphql
 variables:


### PR DESCRIPTION
This is a slightly less common (but still common enough!) file extension used when authoring GraphQL schema files.

No other modifications should be necessary.