### PR TITLE
Add support for interfaces implementing interfaces. Also consider & an operator.

### DIFF
--- a/GraphQL.sublime-syntax
+++ b/GraphQL.sublime-syntax
@@ -111,7 +111,7 @@ contexts:
       push:
         - type-definition
         - directives
-        - type-implements
+        - implements
         - type-name
 
     - match: interface{{name_break}}
@@ -119,6 +119,7 @@ contexts:
       push:
         - type-definition
         - directives
+        - implements
         - interface-name
 
     - match: union{{name_break}}
@@ -361,12 +362,12 @@ contexts:
             - include: else-pop
     - include: else-pop
 
-  type-implements:
+  implements:
     - match: implements{{name_break}}
       scope: keyword.declaration.implements.graphql
       set:
         - - match: '&'
-            scope: punctuation.separator.sequence.graphql
+            scope: keyword.operator.graphql
             push: type-named
           - include: else-pop
         - - include: type-named

--- a/tests/syntax_test_graphql.gql
+++ b/tests/syntax_test_graphql.gql
@@ -235,7 +235,7 @@
 #        ^^^^^^ entity.name.type.object
 #               ^^^^^^^^^^ keyword.declaration.implements
 #                          ^^^ variable.type support.type
-#                              ^ punctuation.separator.sequence
+#                              ^ keyword.operator
 #                                ^^^^^^ variable.type support.type
 #                                       ^ punctuation.definition.annotation
 #                                        ^^^^^^^^^^^ variable.function.annotation
@@ -273,15 +273,17 @@
 #   ^ meta.block punctuation.section.block.end
 
     type myType implements & Int
-#                          ^ punctuation.separator.sequence
+#                          ^ keyword.operator
 #                            ^^^ variable.type support.type
 
-    interface myInterface @myDirective {}
+    interface myInterface implements ParentIf @myDirective {}
 #   ^^^^^^^^^ keyword.declaration.type.interface
 #             ^^^^^^^^^^^ entity.name.type.interface
-#                         ^ punctuation.definition.annotation
-#                          ^^^^^^^^^^^ variable.function.annotation
-#                                      ^^ meta.block
+#                         ^^^^^^^^^^ keyword.declaration.implements
+#                                    ^^^^^^^^ variable.type
+#                                             ^ punctuation.definition.annotation
+#                                              ^^^^^^^^^^^ variable.function.annotation
+#                                                          ^^ meta.block
 
     union myUnion = Int | String
 #   ^^^^^ keyword.declaration.type.interface


### PR DESCRIPTION
Fixes: #13 
Also makes ampersands, which are very similar to vertical pipes in their meaning, have the same operator based scope as vertical pipes.