### PR TITLE
Fix docstrings ending with more than 3 double quotes

### DIFF
--- a/GraphQL.sublime-syntax
+++ b/GraphQL.sublime-syntax
@@ -160,7 +160,7 @@ contexts:
         - meta_scope: string.quoted.multiline.graphql
         - match: '\\"""'
           scope: constant.character.escape.graphql
-        - match: '"""'
+        - match: '"{3,5}'
           scope: string.quoted.multiline.end.graphql
           pop: true
 


### PR DESCRIPTION
When a docstring ends with a single double quote, like in the following example, the regex would match on the first three double quotes, ending the string, and then the next single double quote would open another string, leading to broken highlighting.

    type Currency {
      """This is the currency code e.g "EUR", "USD""""
      code: String!
    }

Code like this is generated by [Apollo rover]'s schema dump for example.

An issue I could see would be matching 5 quotes of a closing triplet immediately followed by another opening triplet because the regex is probably eager. `"""string1""""""string2""""` could be split into [`"""` `string1` `"""""` `"` `string2` `"` `"` `"`]. But that's probably _really_ uncommon.

[Apollo rover]: https://github.com/apollographql/rover